### PR TITLE
Replace the map with the expected format

### DIFF
--- a/airplay/server.go
+++ b/airplay/server.go
@@ -2,7 +2,6 @@ package airplay
 
 import (
 	"encoding/hex"
-	"fmt"
 	"io/ioutil"
 	"log"
 	"math/rand"
@@ -16,18 +15,18 @@ import (
 var Debug = log.New(ioutil.Discard, "DEBUG ", log.LstdFlags)
 
 // Default TXT Record, have not come up with a new one yet.
-var txt map[string]string = map[string]string{
-	"txtvers": "1",
-	"pw":      "false",
-	"tp":      "UDP",
-	"sm":      "false",
-	"ek":      "1",
-	"cn":      "0,1",
-	"ch":      "2",
-	"ss":      "16",
-	"sr":      "44100",
-	"vn":      "3",
-	"et":      "0,1",
+var txt []string = []string{
+	"txtvers=1",
+	"pw=false",
+	"tp=UDP",
+	"sm=false",
+	"ek=1",
+	"cn=0,1",
+	"ch=2",
+	"ss=16",
+	"sr=44100",
+	"vn=3",
+	"et=0,1",
 }
 
 func RegisterAirTunes(name, address string) (*bonjour.Server, error) {
@@ -47,12 +46,8 @@ func RegisterAirTunes(name, address string) (*bonjour.Server, error) {
 	}
 
 	raopName := hex.EncodeToString(iface.HardwareAddr) + "@" + name
-	keys := make([]string, 0, len(txt))
-	for key, value := range txt {
-		keys = append(keys, fmt.Sprintf("%s=%s", key, value))
-	}
 
-	s, err := bonjour.Register(raopName, "_raop._tcp", "", port, keys, nil)
+	s, err := bonjour.Register(raopName, "_raop._tcp", "", port, txt, nil)
 	if err != nil {
 		log.Fatalln(err.Error())
 	}


### PR DESCRIPTION
The bonjour package expects an array of txt record entries in the format 'field=value'
